### PR TITLE
過去問2020 かつおぶし 難易度4: 単調増加列

### DIFF
--- a/03_katsuobushi/2020_04/pg_2020_04.d
+++ b/03_katsuobushi/2020_04/pg_2020_04.d
@@ -1,0 +1,85 @@
+// PG Battle 2020 かつおぶし 難易度4: 短調増加列
+// https://products.sint.co.jp/hubfs/resource/topsic/pgb2020/3_2.pdf
+
+void main() { runSolver(); }
+
+void problem() {
+  auto N = scan!int;
+  auto S = scan!int;
+  
+  auto solve() {
+    int[][] ans;
+
+    // arr: 作成中の数列
+    // index: 何番目の値を足そうとしているか
+    // rest: 残りの数 (S - arr.sum)
+    void dfs(DList!int arr, int index, int rest) {
+      if (index == N) {
+        // 長さがNになって、残り数も0ならいい感じなので、答えとして出力
+        if (rest == 0) writefln("%(%d %)", arr.array);
+        return;
+      }
+
+      auto pre = arr.empty ? 1 : arr.back;
+      foreach(n; pre..S + 1) {
+        // 残りをどう頑張っても N を超えちゃう場合
+        if (n * (N - index) > rest) break;
+
+        arr.insertBack(n);
+        dfs(arr, index + 1, rest - n);
+        arr.removeBack();
+      }
+    }
+
+    // DFSで空の配列に、いい感じに数を足してく
+    dfs(DList!int(), 0, S);
+  }
+
+  outputForAtCoder(&solve);
+}
+
+// ----------------------------------------------
+
+import std;
+string scan(){ static string[] ss; while(!ss.length) ss = readln.chomp.split; string res = ss[0]; ss.popFront; return res; }
+T scan(T)(){ return scan.to!T; }
+T[] scan(T)(long n){ return n.iota.map!(i => scan!T()).array; }
+T[] compress(T)(T[] arr, T origin = T.init) { T[T] indecies; arr.dup.sort.uniq.enumerate(origin).each!((i, t) => indecies[t] = i); return arr.map!(t => indecies[t]).array; }
+long[] divisors(long n) { long[] ret; for (long i = 1; i * i <= n; i++) { if (n % i == 0) { ret ~= i; if (i * i != n) ret ~= n / i; } } return ret.sort.array; }
+bool chmin(T)(ref T a, T b) { if (b < a) { a = b; return true; } else return false; }
+bool chmax(T)(ref T a, T b) { if (b > a) { a = b; return true; } else return false; }
+ulong comb(ulong a, ulong b) { if (b == 0) {return 1;}else{return comb(a - 1, b - 1) * a / b;}}
+struct ModInt(uint MD) if (MD < int.max) {ulong v;this(string v) {this(v.to!long);}this(int v) {this(long(v));}this(long v) {this.v = (v%MD+MD)%MD;}void opAssign(long t) {v = (t%MD+MD)%MD;}static auto normS(ulong x) {return (x<MD)?x:x-MD;}static auto make(ulong x) {ModInt m; m.v = x; return m;}auto opBinary(string op:"+")(ModInt r) const {return make(normS(v+r.v));}auto opBinary(string op:"-")(ModInt r) const {return make(normS(v+MD-r.v));}auto opBinary(string op:"*")(ModInt r) const {return make((ulong(v)*r.v%MD).to!ulong);}auto opBinary(string op:"^^", T)(T r) const {long x=v;long y=1;while(r){if(r%2==1)y=(y*x)%MD;x=x^^2%MD;r/=2;} return make(y);}auto opBinary(string op:"/")(ModInt r) const {return this*memoize!inv(r);}static ModInt inv(ModInt x) {return x^^(MD-2);}string toString() const {return v.to!string;}auto opOpAssign(string op)(ModInt r) {return mixin ("this=this"~op~"r");}}
+alias MInt1 = ModInt!(10^^9 + 7);
+alias MInt9 = ModInt!(998_244_353);
+string asAnswer(T ...)(T t) {
+  string ret;
+  foreach(i, a; t) {
+    if (i > 0) ret ~= "\n";
+    alias A = typeof(a);
+    static if (isIterable!A && !is(A == string)) {
+      string[] rets;
+      foreach(b; a) rets ~= asAnswer(b);
+      static if (isInputRange!A) ret ~= rets.joiner(" ").to!string; else ret ~= rets.joiner("\n").to!string; 
+    } else {
+      static if (is(A == float) || is(A == double) || is(A == real)) ret ~= "%.16f".format(a);
+      else static if (is(A == bool)) ret ~= YESNO[a]; else ret ~= "%s".format(a);
+    }
+  }
+  return ret;
+}
+void deb(T ...)(T t){ debug t.writeln; }
+void outputForAtCoder(T)(T delegate() fn) {
+  static if (is(T == void)) fn();
+  else if (is(T == string)) fn().writeln;
+  else asAnswer(fn()).writeln;
+}
+void runSolver() {
+  static import std.datetime.stopwatch;
+  enum BORDER = "==================================";
+  debug { BORDER.writeln; while(!stdin.eof) { "<<< Process time: %s >>>".writefln(std.datetime.stopwatch.benchmark!problem(1)); BORDER.writeln; } }
+  else problem();
+}
+enum YESNO = [true: "Yes", false: "No"];
+
+// -----------------------------------------------


### PR DESCRIPTION
## 解いた問題

PG BATTLE 20210かつおぶし 難易度４「単調増加列」
https://products.sint.co.jp/hubfs/resource/topsic/pgb2021/3_1.pdf

## 問題の解釈

1以上の整数で構成されるサイズNの数列のうち、広義単調増加列で合計が S となるものを求めてください。
複数ある場合、辞書順に全てを出力してね。

## 実装方針

最近のABCでよく見る、実装がちょっと面倒なタイプの全探索かなーと思った。
深さ優先探索で、空数列の状態から入れられるだけ数を入れていく感じの実装をしてみました。

## 想定する計算量

わからん！！ 
Sが大きいほど厳しくなるのは間違いないのだけど、Nは計算量に純粋に比例しないのでむずい。
N = 50, S = 50 とか、 N = 10, S = 50 とかでも1秒かからないので多分大丈夫かなあ。
S = 50 で N を全部試して2秒超えない感じならTLEにはならないはず。
