### PR TITLE
過去問2021 かつおぶし 難易度6「ペアなすごろく」

### DIFF
--- a/03_katsuobushi/2021_06/pg_2021_06.d
+++ b/03_katsuobushi/2021_06/pg_2021_06.d
@@ -1,0 +1,74 @@
+void main() { runSolver(); }
+
+// https://products.sint.co.jp/hubfs/resource/topsic/pgb2021/3_3.pdf
+void problem() {
+  auto N = scan!int;
+  auto R = scan!int(N);
+
+  auto solve() {
+    auto pairCounts = 200001.iota.map!(n => n == 0 ? MInt9(0) : MInt9(1) / MInt9(n * (n + 1) / 2)).array;
+    
+    auto dp = new MInt9[](N);
+    MInt9 ans;
+    dp[0] = MInt9(1);
+    foreach(x; 0..N) {
+      foreach(p; 1..R[x] + 1) {
+        if (p + x < N) {
+          dp[p + x] += dp[x] * MInt9(R[x] - p + 1) * pairCounts[R[x]];
+        } else {
+          ans += MInt9(p + x + 1) * dp[x] * MInt9(R[x] - p + 1) * pairCounts[R[x]];
+        }
+      }
+    }
+
+    return ans;
+  }
+
+  outputForAtCoder(&solve);
+}
+
+// ----------------------------------------------
+
+import std;
+string scan(){ static string[] ss; while(!ss.length) ss = readln.chomp.split; string res = ss[0]; ss.popFront; return res; }
+T scan(T)(){ return scan.to!T; }
+T[] scan(T)(long n){ return n.iota.map!(i => scan!T()).array; }
+T[] compress(T)(T[] arr, T origin = T.init) { T[T] indecies; arr.dup.sort.uniq.enumerate(origin).each!((i, t) => indecies[t] = i); return arr.map!(t => indecies[t]).array; }
+long[] divisors(long n) { long[] ret; for (long i = 1; i * i <= n; i++) { if (n % i == 0) { ret ~= i; if (i * i != n) ret ~= n / i; } } return ret.sort.array; }
+bool chmin(T)(ref T a, T b) { if (b < a) { a = b; return true; } else return false; }
+bool chmax(T)(ref T a, T b) { if (b > a) { a = b; return true; } else return false; }
+ulong comb(ulong a, ulong b) { if (b == 0) {return 1;}else{return comb(a - 1, b - 1) * a / b;}}
+struct ModInt(uint MD) if (MD < int.max) {ulong v;this(string v) {this(v.to!long);}this(int v) {this(long(v));}this(long v) {this.v = (v%MD+MD)%MD;}void opAssign(long t) {v = (t%MD+MD)%MD;}static auto normS(ulong x) {return (x<MD)?x:x-MD;}static auto make(ulong x) {ModInt m; m.v = x; return m;}auto opBinary(string op:"+")(ModInt r) const {return make(normS(v+r.v));}auto opBinary(string op:"-")(ModInt r) const {return make(normS(v+MD-r.v));}auto opBinary(string op:"*")(ModInt r) const {return make((ulong(v)*r.v%MD).to!ulong);}auto opBinary(string op:"^^", T)(T r) const {long x=v;long y=1;while(r){if(r%2==1)y=(y*x)%MD;x=x^^2%MD;r/=2;} return make(y);}auto opBinary(string op:"/")(ModInt r) const {return this*memoize!inv(r);}static ModInt inv(ModInt x) {return x^^(MD-2);}string toString() const {return v.to!string;}auto opOpAssign(string op)(ModInt r) {return mixin ("this=this"~op~"r");}}
+alias MInt1 = ModInt!(10^^9 + 7);
+alias MInt9 = ModInt!(998_244_353);
+string asAnswer(T ...)(T t) {
+  string ret;
+  foreach(i, a; t) {
+    if (i > 0) ret ~= "\n";
+    alias A = typeof(a);
+    static if (isIterable!A && !is(A == string)) {
+      string[] rets;
+      foreach(b; a) rets ~= asAnswer(b);
+      static if (isInputRange!A) ret ~= rets.joiner(" ").to!string; else ret ~= rets.joiner("\n").to!string; 
+    } else {
+      static if (is(A == float) || is(A == double) || is(A == real)) ret ~= "%.16f".format(a);
+      else static if (is(A == bool)) ret ~= YESNO[a]; else ret ~= "%s".format(a);
+    }
+  }
+  return ret;
+}
+void deb(T ...)(T t){ debug t.writeln; }
+void outputForAtCoder(T)(T delegate() fn) {
+  static if (is(T == void)) fn();
+  else static if (is(T == string)) fn().writeln;
+  else asAnswer(fn()).writeln;
+}
+void runSolver() {
+  static import std.datetime.stopwatch;
+  enum BORDER = "==================================";
+  debug { BORDER.writeln; while(!stdin.eof) { "<<< Process time: %s >>>".writefln(std.datetime.stopwatch.benchmark!problem(1)); BORDER.writeln; } }
+  else problem();
+}
+enum YESNO = [true: "Yes", false: "No"];
+
+// -----------------------------------------------

--- a/03_katsuobushi/2021_06/pg_2021_06.d
+++ b/03_katsuobushi/2021_06/pg_2021_06.d
@@ -6,19 +6,28 @@ void problem() {
   auto R = scan!int(N);
 
   auto solve() {
-    auto pairCounts = 200001.iota.map!(n => n == 0 ? MInt9(0) : MInt9(1) / MInt9(n * (n + 1) / 2)).array;
+    enum MAX = 200_001;
+    auto invPairs = MAX.iota.map!(n => n == 0 ? MInt9(0) : MInt9(1) / MInt9(n * (n + 1) / 2)).array;
     
-    auto dp = new MInt9[](N);
-    MInt9 ans;
-    dp[0] = MInt9(1);
+    auto deltas = new MInt9[](MAX * 2 + 1);
+    MInt9 delta, rate;
     foreach(x; 0..N) {
-      foreach(p; 1..R[x] + 1) {
-        if (p + x < N) {
-          dp[p + x] += dp[x] * MInt9(R[x] - p + 1) * pairCounts[R[x]];
-        } else {
-          ans += MInt9(p + x + 1) * dp[x] * MInt9(R[x] - p + 1) * pairCounts[R[x]];
-        }
-      }
+      const r = x == 0 ? MInt9(1) : rate;
+      const dice = R[x];
+
+      delta += deltas[x];
+      deltas[x + 1] -= r * invPairs[dice];
+      deltas[x + 1 + dice] += r * invPairs[dice];
+
+      rate += delta;
+      rate += r * MInt9(dice) * invPairs[dice];
+    }
+
+    MInt9 ans;
+    foreach(x; N..MAX * 2) {
+      ans += MInt9(x + 1) * rate;
+      delta += deltas[x];
+      rate += delta;
     }
 
     return ans;


### PR DESCRIPTION
## 解いた問題
過去問2021 かつおぶし 難易度6「ペアなすごろく」
https://products.sint.co.jp/hubfs/resource/topsic/pgb/3-3.pdf

## 問題の解釈

### 前提事項
- 変わったサイコロを使ってすごろくをやる。
  - このサイコロは小さい値ほど出やすい感じになっている。
    - 具体的には、6面の場合 1..6 の順に `[6, 5, 4, 3, 2, 1]` の比で出やすい。
  - サイコロはマス目ごとに用意 (入力R) されるので、今いるマス目にあるものを振って進める。
- サイコロのあるマス目は序盤の N マスだけ。それを超えたマス目に到達したらゴール。
 
### 出力する内容
ゴール時のマス目の番号の期待値はいくつですか？
 
## 実装方針
とてもむずい。80分間くらいかかってるので本番では無理っぽい。

基本は確率DPの形で解ける。最後にゴール地点を掛けて期待値にする。
ナイーブ(TLEになる)実装 `O(N * ΣR)` は10分間程度でできる。
a6de4342bcbbad784d1bdb984432ed9e11d46e2d

そこから高速化する必要がある。累積和を適用できないか考えたけど、計算式的に無理っぽかった。
imos法という累積和の亜種テクニックを用いたらいい感じに解けた。
高速化をしてTLEを回避するための修正はこの差分 => 41969dfb550b2e7fb9fd494f0fb26f4398e88f3f

## 想定する計算量

全てのケースで 4 * 10^^5 マス目までの計算を行っているため `O(10^^5)` .. と言いたいところですが
ありうる全てのサイコロについて分布の前計算をしている部分が `O(10^^5 * logMOD)` なのでそちらがネック。

### Wandbox でのコード共有
https://wandbox.org/permlink/4DWWJI6ze1IB3lLc
