### PR TITLE
PG BATTLE 2019 かつおぶし 難易度3: 距離最小最大

### DIFF
--- a/03_katsuobushi/2019_03/pg_2019_03.d
+++ b/03_katsuobushi/2019_03/pg_2019_03.d
@@ -1,0 +1,106 @@
+void main() { runSolver(); }
+
+// PG BATTLE 2019 かつおぶし 難易度3: 距離最小最大
+// https://products.sint.co.jp/hubfs/resource/topsic/pgb/3-1.pdf
+void problem() {
+  auto N = scan!int;
+  auto A = scan!int(N * 2);
+
+  auto solve() {
+    bool isOk(int m) {
+      // すべてのペアを |a - b| >= m で作ることを試行する。無理なら false を返す
+      auto rbt = A.redBlackTree!true;
+      while(!rbt.empty) {
+        // 残ってる数のうち、最小のものを持ってくる
+        auto smallest = rbt.front;
+        rbt.removeFront;
+
+        // 上の数 + m 以上の値があるかチェック。なければ無理と判断。いける場合、そのうちの最小値を使ってペアとする
+        auto candidates = rbt.upperBound(smallest + m - 1);
+        if (candidates.empty) return false;
+
+        rbt.removeKey(candidates.front);
+      }
+      return true;
+    }
+
+    // 上の関数の引数で二分探索。「答えを二分探索」のふるまい
+    return binarySearch(&isOk, 0, 10^^9);
+  }
+
+  outputForAtCoder(&solve);
+}
+
+// ----------------------------------------------
+
+import std;
+string scan(){ static string[] ss; while(!ss.length) ss = readln.chomp.split; string res = ss[0]; ss.popFront; return res; }
+T scan(T)(){ return scan.to!T; }
+T[] scan(T)(long n){ return n.iota.map!(i => scan!T()).array; }
+T[] compress(T)(T[] arr, T origin = T.init) { T[T] indecies; arr.dup.sort.uniq.enumerate(origin).each!((i, t) => indecies[t] = i); return arr.map!(t => indecies[t]).array; }
+long[] divisors(long n) { long[] ret; for (long i = 1; i * i <= n; i++) { if (n % i == 0) { ret ~= i; if (i * i != n) ret ~= n / i; } } return ret.sort.array; }
+bool chmin(T)(ref T a, T b) { if (b < a) { a = b; return true; } else return false; }
+bool chmax(T)(ref T a, T b) { if (b > a) { a = b; return true; } else return false; }
+ulong comb(ulong a, ulong b) { if (b == 0) {return 1;}else{return comb(a - 1, b - 1) * a / b;}}
+struct ModInt(uint MD) if (MD < int.max) {ulong v;this(string v) {this(v.to!long);}this(int v) {this(long(v));}this(long v) {this.v = (v%MD+MD)%MD;}void opAssign(long t) {v = (t%MD+MD)%MD;}static auto normS(ulong x) {return (x<MD)?x:x-MD;}static auto make(ulong x) {ModInt m; m.v = x; return m;}auto opBinary(string op:"+")(ModInt r) const {return make(normS(v+r.v));}auto opBinary(string op:"-")(ModInt r) const {return make(normS(v+MD-r.v));}auto opBinary(string op:"*")(ModInt r) const {return make((ulong(v)*r.v%MD).to!ulong);}auto opBinary(string op:"^^", T)(T r) const {long x=v;long y=1;while(r){if(r%2==1)y=(y*x)%MD;x=x^^2%MD;r/=2;} return make(y);}auto opBinary(string op:"/")(ModInt r) const {return this*memoize!inv(r);}static ModInt inv(ModInt x) {return x^^(MD-2);}string toString() const {return v.to!string;}auto opOpAssign(string op)(ModInt r) {return mixin ("this=this"~op~"r");}}
+alias MInt1 = ModInt!(10^^9 + 7);
+alias MInt9 = ModInt!(998_244_353);
+string asAnswer(T ...)(T t) {
+  string ret;
+  foreach(i, a; t) {
+    if (i > 0) ret ~= "\n";
+    alias A = typeof(a);
+    static if (isIterable!A && !is(A == string)) {
+      string[] rets;
+      foreach(b; a) rets ~= asAnswer(b);
+      static if (isInputRange!A) ret ~= rets.joiner(" ").to!string; else ret ~= rets.joiner("\n").to!string; 
+    } else {
+      static if (is(A == float) || is(A == double) || is(A == real)) ret ~= "%.16f".format(a);
+      else static if (is(A == bool)) ret ~= YESNO[a]; else ret ~= "%s".format(a);
+    }
+  }
+  return ret;
+}
+void deb(T ...)(T t){ debug t.writeln; }
+void outputForAtCoder(T)(T delegate() fn) {
+  static if (is(T == void)) fn();
+  else if (is(T == string)) fn().writeln;
+  else asAnswer(fn()).writeln;
+}
+void runSolver() {
+  static import std.datetime.stopwatch;
+  enum BORDER = "==================================";
+  debug { BORDER.writeln; while(!stdin.eof) { "<<< Process time: %s >>>".writefln(std.datetime.stopwatch.benchmark!problem(1)); BORDER.writeln; } }
+  else problem();
+}
+enum YESNO = [true: "Yes", false: "No"];
+
+// -----------------------------------------------
+
+K binarySearch(K)(bool delegate(K) cond, K l, K r) { return binarySearch((K k) => k, cond, l, r); }
+T binarySearch(T, K)(K delegate(T) fn, bool delegate(K) cond, T l, T r) {
+  auto ok = l;
+  auto ng = r;
+  const T TWO = 2;
+ 
+  bool again() {
+    static if (is(T == float) || is(T == double) || is(T == real)) {
+      return !ng.approxEqual(ok, 1e-08, 1e-08);
+    } else {
+      return abs(ng - ok) > 1;
+    }
+  }
+ 
+  while(again()) {
+    const half = (ng + ok) / TWO;
+    const halfValue = fn(half);
+ 
+    if (cond(halfValue)) {
+      ok = half;
+    } else {
+      ng = half;
+    }
+  }
+ 
+  return ok;
+}


### PR DESCRIPTION
## 解いた問題
PG BATTLE 2019 かつおぶし 難易度3: 距離最小最大
https://products.sint.co.jp/hubfs/resource/topsic/pgb/3-1.pdf

## 問題の解釈
数字が 2N 個あるので、N個のペアを作ってね。
ペアの数字を a, b とするとき、その差の絶対値の最小値ができるだけ大きくなるようにしてほしい。
限界まで努力してペアを作ったとき「絶対値の最小値」はどこまで大きくできる？

## 実装方針
とりあえず数は昇順に並べておくと考えやすくなりそう。

ここから戦略を考えるが、たとえば `1 2 4 8` の場合、隣り合った数字を選ぶのが最も悪い選択だろう。なので、できればある程度遠い数をペアとするのがよさそう。
ただ、遠ければ遠いほど良いのか？というとそうでもない。最後に残った数がどんどん悪くなってしまうので。
などと考えてると、ルールベースでいい感じの数を選ぶのは無理そうという気持ちになる。

こういう場合は発想を変える。まずは答えを M と固定する。
「全てのペアの絶対値が M以上 になるように全ペアを作れるか？」という問題に置き換えてみる。
これは比較的簡単に実装できるので、この関数に対して false/true の境界を二分探索で求めればよい。
いわゆる「答えで二分探索」の形に持ち込むことができる、というやつ。

## 想定する計算量

O(NlogN * log(10**9))
